### PR TITLE
add a case to the JS test to confirm ignoring node_modules

### DIFF
--- a/pkg/comments/comments_test.go
+++ b/pkg/comments/comments_test.go
@@ -13,7 +13,7 @@ func TestJSFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(comments) != 2 {
+	if len(comments) != 3 {
 		t.Fail()
 	}
 }

--- a/pkg/comments/testdata/javascript/node_modules/ignored.js
+++ b/pkg/comments/testdata/javascript/node_modules/ignored.js
@@ -1,0 +1,2 @@
+// the comments in this file should be ignored, since it's in a "vendor" path
+

--- a/pkg/comments/testdata/javascript/subdir/index.js
+++ b/pkg/comments/testdata/javascript/subdir/index.js
@@ -1,0 +1,2 @@
+// this comment should be found
+


### PR DESCRIPTION
Came up via https://github.com/augmentable-dev/tickgit/issues/32