### PR TITLE
Add support for more matching phrases

### DIFF
--- a/pkg/comments/comments.go
+++ b/pkg/comments/comments.go
@@ -43,7 +43,7 @@ func SearchFile(filePath string, reader io.Reader, cb func(*Comment)) error {
 		return nil
 	}
 	options, ok := LanguageParseOptions[lang]
-	if !ok { // TODO provide a default parse option?
+	if !ok { // TODO provide a default parse option for when we don't know how to handle a language? I.e. default to CStyle comments say
 		return nil
 	}
 	commentParser, err := lege.NewParser(options)

--- a/pkg/todos/report.go
+++ b/pkg/todos/report.go
@@ -2,13 +2,13 @@ package todos
 
 import (
 	"io"
+	"strings"
 	"text/template"
 )
 
-// DefaultTemplate is the default report template
-const DefaultTemplate = `
+const defaultTemplate = `
 {{- range $index, $todo := . }}
-{{ print "\u001b[33m" }}TODO{{ print "\u001b[0m" }}: {{ .String }}
+{{ .String }}
   => {{ .Comment.FilePath }}:{{ .Comment.StartLocation.Line }}:{{ .Comment.StartLocation.Pos }}
   {{- if .Blame }}
   => added {{ .TimeAgo }} by {{ .Blame.Author }} in {{ .Blame.SHA }}
@@ -22,9 +22,15 @@ no todos 🎉
 // WriteTodos renders a report of todos
 func WriteTodos(todos ToDos, writer io.Writer) error {
 
-	t, err := template.New("todos").Parse(DefaultTemplate)
+	t, err := template.New("todos").Parse(defaultTemplate)
 	if err != nil {
 		return err
+	}
+
+	// replace the phrase in the todo string with a "highlighted" version for console output
+	// TODO eventually make this configurable, for NO_COLOR output (or customization of color?)
+	for _, todo := range todos {
+		todo.String = strings.Replace(todo.String, todo.Phrase, "\u001b[33m"+todo.Phrase+"\u001b[0m", 1)
 	}
 
 	err = t.Execute(writer, todos)

--- a/pkg/todos/todos_test.go
+++ b/pkg/todos/todos_test.go
@@ -1,0 +1,36 @@
+package todos
+
+import (
+	"testing"
+
+	"github.com/augmentable-dev/lege"
+	"github.com/augmentable-dev/tickgit/pkg/comments"
+)
+
+func TestNewToDoNil(t *testing.T) {
+	collection := lege.NewCollection(lege.Location{}, lege.Location{}, lege.Boundary{}, "Hello World")
+	comment := comments.Comment{
+		Collection: *collection,
+	}
+	todo := NewToDo(comment)
+
+	if todo != nil {
+		t.Fatalf("did not expect a TODO, got: %v", todo)
+	}
+}
+
+func TestNewToDo(t *testing.T) {
+	collection := lege.NewCollection(lege.Location{}, lege.Location{}, lege.Boundary{}, "TODO Hello World")
+	comment := comments.Comment{
+		Collection: *collection,
+	}
+	todo := NewToDo(comment)
+
+	if todo == nil {
+		t.Fatalf("expected a TODO, got: %v", todo)
+	}
+
+	if todo.Phrase != "TODO" {
+		t.Fatalf("expected matched phrase to be TODO, got: %s", todo.Phrase)
+	}
+}


### PR DESCRIPTION
not yet configurable, but adds matching for `TODO`, `FIXME`, `OPTIMIZE`, `HACK`, `XXX`, `WTF`, `LEGACY` and their @ + lowerCase version equivalents - `@todo`, `@fixme` etc by default.

Closes #35 